### PR TITLE
fix: resolve TruffleHog CI failure on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint:
     name: "Lint & Type Check"
@@ -82,7 +85,6 @@ jobs:
         run: |
           cd backend
           uv sync
-          # We can add more specific python safety tools here later if needed
 
       - name: Frontend Audit
         run: |
@@ -94,6 +96,6 @@ jobs:
       - name: Secret Scan (TruffleHog)
         uses: trufflesecurity/trufflehog@main
         with:
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           extra_args: --debug --only-verified


### PR DESCRIPTION
Closes #29.

Fixes the TruffleHog failure on the 'main' branch by correctly calculating the commit range for both PRs and direct pushes. Also adds the environment variable to opt-in to Node.js 24 for actions to suppress deprecation warnings.