### PR TITLE
feat: In-App Ollama Model Pulling

### DIFF
--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from app.gateway.routers import models, stats, threads
+from app.gateway.routers import models, ollama, stats, threads
 from deerflow.config.app_config import get_app_config
 
 logging.basicConfig(
@@ -44,6 +44,7 @@ def create_app() -> FastAPI:
         openapi_tags=[
             {"name": "models", "description": "Available AI models"},
             {"name": "threads", "description": "Research thread management"},
+            {"name": "ollama", "description": "Ollama service integration"},
             {"name": "health", "description": "Health check"},
         ],
     )
@@ -51,6 +52,7 @@ def create_app() -> FastAPI:
     app.include_router(models.router)
     app.include_router(stats.router)
     app.include_router(threads.router)
+    app.include_router(ollama.router)
 
     @app.get("/health", tags=["health"])
     async def health_check() -> dict:

--- a/backend/app/gateway/routers/ollama.py
+++ b/backend/app/gateway/routers/ollama.py
@@ -1,0 +1,51 @@
+import json
+import logging
+import os
+
+import httpx
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/ollama", tags=["ollama"])
+
+_OLLAMA_BASE = os.environ.get("OLLAMA_BASE_URL", "http://host.docker.internal:11434")
+
+
+class PullRequest(BaseModel):
+    model: str
+
+
+@router.post("/pull")
+async def pull_model(request: PullRequest):
+    """Proxy a pull request to the local Ollama instance and stream the response."""
+    model_name = request.model.strip()
+    if not model_name:
+        raise HTTPException(status_code=400, detail="Model name is required")
+
+    async def generate():
+        try:
+            async with httpx.AsyncClient(timeout=None) as client:
+                req = client.build_request(
+                    "POST",
+                    f"{_OLLAMA_BASE}/api/pull",
+                    json={"name": model_name, "stream": True},
+                )
+                response = await client.send(req, stream=True)
+                if response.status_code != 200:
+                    error_text = await response.aread()
+                    yield json.dumps({"error": f"Ollama error {response.status_code}: {error_text.decode('utf-8', errors='ignore')}"}) + "\n"
+                    return
+
+                async for line in response.aiter_lines():
+                    if line:
+                        yield line + "\n"
+        except httpx.RequestError as e:
+            logger.error("Failed to connect to Ollama: %s", e)
+            yield json.dumps({"error": "Failed to connect to Ollama service."}) + "\n"
+        except Exception as e:
+            logger.exception("Unexpected error during model pull")
+            yield json.dumps({"error": str(e)}) + "\n"
+
+    return StreamingResponse(generate(), media_type="application/x-ndjson")

--- a/frontend/src/components/workspace/dashboard.tsx
+++ b/frontend/src/components/workspace/dashboard.tsx
@@ -98,6 +98,70 @@ export function Dashboard() {
   const [error, setError] = useState(false);
   const prevPathRef = useRef(pathname);
 
+  // Model Pulling State
+  const [pullModelName, setPullModelName] = useState("");
+  const [isPulling, setIsPulling] = useState(false);
+  const [pullStatus, setPullStatus] = useState("");
+  const [pullProgress, setPullProgress] = useState(0);
+
+  const handlePullModel = async () => {
+    if (!pullModelName.trim() || isPulling) return;
+    setIsPulling(true);
+    setPullStatus("Starting pull...");
+    setPullProgress(0);
+
+    try {
+      const res = await fetch("/api/ollama/pull", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: pullModelName.trim() }),
+      });
+
+      if (!res.ok || !res.body) {
+        throw new Error("Failed to start pull");
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let done = false;
+
+      while (!done) {
+        const { value, done: doneReading } = await reader.read();
+        done = doneReading;
+        if (value) {
+          const chunk = decoder.decode(value, { stream: true });
+          const lines = chunk.split("\\n").filter(Boolean);
+          for (const line of lines) {
+            try {
+              const data = JSON.parse(line);
+              if (data.error) {
+                setPullStatus(`Error: ${data.error}`);
+                setIsPulling(false);
+                return;
+              }
+              setPullStatus(data.status ?? "Pulling...");
+              if (data.total && data.completed) {
+                setPullProgress(Math.round((data.completed / data.total) * 100));
+              }
+            } catch {
+              // ignore parse error on partial chunks
+            }
+          }
+        }
+      }
+      setPullStatus("Pull complete!");
+      setPullModelName("");
+      setTimeout(() => {
+        setPullStatus("");
+        setPullProgress(0);
+      }, 3000);
+    } catch (err: any) {
+      setPullStatus(`Error: ${err.message}`);
+    } finally {
+      setIsPulling(false);
+    }
+  };
+
   // Clear stale scores and subagent data when navigating to a different chat
   useEffect(() => {
     if (pathname !== prevPathRef.current) {
@@ -275,6 +339,41 @@ export function Dashboard() {
               </div>
             </div>
           ))}
+
+        {/* Model Puller UI */}
+        <div className="mt-4 pt-3 border-t border-border/50">
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Pull New Model
+            </span>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={pullModelName}
+                onChange={(e) => setPullModelName(e.target.value)}
+                placeholder="e.g., qwen2.5:7b"
+                className="flex-1 rounded-md border bg-background px-3 py-1 text-sm outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-primary"
+                disabled={isPulling}
+              />
+              <button
+                onClick={handlePullModel}
+                disabled={isPulling || !pullModelName.trim()}
+                className="rounded-md bg-primary text-primary-foreground px-3 py-1 text-sm font-medium disabled:opacity-50 transition-colors"
+              >
+                {isPulling ? "Pulling..." : "Pull"}
+              </button>
+            </div>
+            {pullStatus && (
+              <div className="space-y-1">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted-foreground truncate flex-1 pr-2">{pullStatus}</span>
+                  {pullProgress > 0 && <span className="font-mono">{pullProgress}%</span>}
+                </div>
+                {pullProgress > 0 && <ProgressBar percent={pullProgress} color="bg-blue-500" />}
+              </div>
+            )}
+          </div>
+        </div>
       </section>
 
       {/* Subagent Activity */}


### PR DESCRIPTION
Closes #31.

Adds a seamless 'Pull Model' feature to the frontend dashboard.
- **Backend**: Created a new  endpoint in the gateway that proxies the pull request to the local Ollama instance and streams the NDJSON response.
- **Frontend**: Added a sleek UI component under the Models section in the Dashboard to type a model name (e.g., `qwen2.5:7b`) and pull it. Includes real-time progress bars and status updates parsing the stream.
- Lint and typechecks pass.